### PR TITLE
Fix typo in annotated relations

### DIFF
--- a/annotated/relations.md
+++ b/annotated/relations.md
@@ -102,7 +102,7 @@ class User
 {
     // ...
 
-    /** @ReersTo(target = "Post") */
+    /** @RefersTo(target = "Post") */
     protected $lastPost;
 
     /** @HasMany(target = "Post") */


### PR DESCRIPTION
Replace  `ReersTo` with `RefersTo`