### PR TITLE
Fix example in `Update Entity Schema` chapter

### DIFF
--- a/intro/quick-start.md
+++ b/intro/quick-start.md
@@ -303,7 +303,7 @@ You can modify your entity schema to add new columns. Note that you have to eith
 
 ```php
 /**
-* @Column(type=int,nullable=true)
+* @Column(type="int",nullable=true)
 * @var int|null
 */
 protected $age;


### PR DESCRIPTION
Replace `int` with `"int"`, otherwise it throws an error because couldn't find constant int in property age