### PR TITLE
Undefined index: driver

### DIFF
--- a/basic/connect.md
+++ b/basic/connect.md
@@ -13,7 +13,8 @@ $dbConfig = new Database\Config\DatabaseConfig([
     'default'     => 'default',
     'databases'   => [
         'default' => [
-            'connection' => 'sqlite'
+            'connection' => 'sqlite',
+            'driver'     => 'sqlite'
         ]
     ],
     'connections' => [

--- a/basic/connect.md
+++ b/basic/connect.md
@@ -42,6 +42,7 @@ To register a new database simply add it into `databases` section:
 ```php
 'default' => [
   'connection' => 'sqlite'
+  'driver': 'sqlite'
 ]
 ```
 


### PR DESCRIPTION
PHP 7.2 
Hello @wolfy-j  I got an error which is related to 'Undefined index: driver' If I pass a driver param in default it'll work. I discovered a place when it's happening.
```php
public function getDatabase(string $database): DatabasePartial
    {
        if (!$this->hasDatabase($database)) {
            throw new ConfigException("Undefined database `{$database}`.");
        }

        $config = $this->config['databases'][$database];

        return new DatabasePartial(
            $database,
            $config['tablePrefix'] ?? $config['prefix'] ?? '',
            $config['connection'] ?? $config['write'] ?? $config['driver'],
            $config['readConnection'] ?? $config['read'] ?? $config['readDriver'] ?? null
        );
    }
```