### PR TITLE
Add fully qualified namespace for morphed relations

### DIFF
--- a/relation/morphed.md
+++ b/relation/morphed.md
@@ -38,6 +38,8 @@ class Image
 
 You can use your relation as a standard hasOne after that. **Note, eager loading is not possible with `belongsToMorphed` relation type.**
 
+Note: In order to be able to use the annotation as `@BelongsToMorphed`, you need to import it with `use Cycle\Annotated\Annotation\Relation\Morphed\BelongsToMorphed;`
+
 ## Variations
 The ORM provides three basic relations for polymorphic connections:
 


### PR DESCRIPTION
I thought the fully qualified namespace for morphed relations should be mentioned, since I expected them to live in the same namespace as standard relations.

Maybe the same information should be added in [annotated/relations.md](cycle/docs/edit/master/annotated/relations.md) in the _Morphed relations_ section?