### PR TITLE
Updated class path for repository

### DIFF
--- a/annotated/entity.md
+++ b/annotated/entity.md
@@ -41,7 +41,7 @@ Some options can be used to overwrite default entity behaviour, for example to a
 use Cycle\Annotated\Annotation\Entity;
 
 /**
- * @Entity(repository = "Repository/UserRepository")
+ * @Entity(repository = "Repository\UserRepository")
  */
 class User
 {
@@ -71,7 +71,7 @@ use Cycle\Annotated\Annotation\Entity;
 /**
  * @Entity(
  *    table      = "users",
- *    repository = "Repository/UserRepository",
+ *    repository = "Repository\UserRepository",
  *    constrain  = "Constrain/SortByID"
  * )
  */


### PR DESCRIPTION
Description
----
Using forward slash `/` is causing `is_subclass_of` to return `false` when calling
https://github.com/cycle/orm/blob/master/src/Factory.php#L160

### Steps to reproduce:
```
composer create-project spiral/app test-spiral
cd test-spiral
php app.php create:entity User
php app.php create:repository User
```

Edit the generated entity in `app/src/Database/User.php` add column and repository annotations, example:

```
<?php

declare(strict_types=1);

namespace App\Database;

use Cycle\Annotated\Annotation as Cycle;

/**
 * @Cycle\Entity(repository = "App/Repository/UserRepository")
 */
class User
{
    /** @Cycle\Column(type="primary") */
    public $id;
}
```

Run `cycle`

```
php app.php cycle
```

Update the `HomeController` `index` method:

```
public function index(): ResponseInterface
{
    return $this->response->json($this->orm->getRepository(User::class)->findAll());
}
```

Start app
```
./spiral serve -v -d
```

Visit root route output by above command (probably http://localhost:8080), you should see this error:
```
Cycle\ORM\Exception\TypecastException: App/Repository/UserRepository does not implement Cycle\ORM\RepositoryInterface
```

If you change the annotation on the `User` entity to:
```
@Cycle\Entity(repository = "App\Repository\UserRepository")
```

Re-run `cycle`:
```
php app.php cycle
```

Start the app and visit root route, it should work now
```
./spiral serve -v -d
```