### PR TITLE
Syntax error in declaration docs

### DIFF
--- a/advanced/declaration.md
+++ b/advanced/declaration.md
@@ -214,7 +214,7 @@ $schema->string('email');
 $schema->index(['email']); //Simple index
 $schema->column('email')->index(); //You can also use alternative declaration for simple indexes
 
-$schema->index(['name', 'email']; //Compound index
+$schema->index(['name', 'email']); //Compound index
 
 $schema->save();
 ```


### PR DESCRIPTION
Description
----
There's a small syntax error in the "Indexes" section, missing closed parentheses :)